### PR TITLE
Re-translate binCleanupTab / binCleanupIgnore after English rename (39 languages)

### DIFF
--- a/locales/ar-SA.json
+++ b/locales/ar-SA.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "التبديل إلى عرض مدمج",
 	"binSwitchToDetailed": "التبديل إلى عرض مفصل",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Cleanup suggestions",
+	"binCleanupTab": "تنظيف",
 	"binCleanupDescription": "Objects and files no longer linked to the object they were created in, and not used in any other object.",
 	"binCleanupCreatedIn": "Created in",
 	"binCleanupLinkRemovedFrom": "Link removed from",
 	"binCleanupContextDeleted": "Deleted object",
-	"binCleanupIgnore": "Keep it",
+	"binCleanupIgnore": "تجاهل الاقتراح",
 	"binDeleteDisabledTooltip": "تستطيع فقط حذف الأشياء التي قمت بإنشائها"
 }

--- a/locales/be-BY.json
+++ b/locales/be-BY.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Switch to compact view",
 	"binSwitchToDetailed": "Switch to detailed view",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Cleanup suggestions",
+	"binCleanupTab": "Ачыстка",
 	"binCleanupDescription": "Objects and files no longer linked to the object they were created in, and not used in any other object.",
 	"binCleanupCreatedIn": "Created in",
 	"binCleanupLinkRemovedFrom": "Link removed from",
 	"binCleanupContextDeleted": "Deleted object",
-	"binCleanupIgnore": "Keep it",
+	"binCleanupIgnore": "Адхіліць прапанову",
 	"binDeleteDisabledTooltip": "You can only delete objects you created"
 }

--- a/locales/bg-BG.json
+++ b/locales/bg-BG.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Switch to compact view",
 	"binSwitchToDetailed": "Switch to detailed view",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Cleanup suggestions",
+	"binCleanupTab": "Почистване",
 	"binCleanupDescription": "Objects and files no longer linked to the object they were created in, and not used in any other object.",
 	"binCleanupCreatedIn": "Created in",
 	"binCleanupLinkRemovedFrom": "Link removed from",
 	"binCleanupContextDeleted": "Deleted object",
-	"binCleanupIgnore": "Keep it",
+	"binCleanupIgnore": "Отхвърли предложението",
 	"binDeleteDisabledTooltip": "You can only delete objects you created"
 }

--- a/locales/ca-ES.json
+++ b/locales/ca-ES.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Switch to compact view",
 	"binSwitchToDetailed": "Switch to detailed view",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Cleanup suggestions",
+	"binCleanupTab": "Neteja",
 	"binCleanupDescription": "Objects and files no longer linked to the object they were created in, and not used in any other object.",
 	"binCleanupCreatedIn": "Created in",
 	"binCleanupLinkRemovedFrom": "Link removed from",
 	"binCleanupContextDeleted": "Deleted object",
-	"binCleanupIgnore": "Keep it",
+	"binCleanupIgnore": "Descarta el suggeriment",
 	"binDeleteDisabledTooltip": "You can only delete objects you created"
 }

--- a/locales/cs-CZ.json
+++ b/locales/cs-CZ.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Switch to compact view",
 	"binSwitchToDetailed": "Switch to detailed view",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Cleanup suggestions",
+	"binCleanupTab": "Úklid",
 	"binCleanupDescription": "Objects and files no longer linked to the object they were created in, and not used in any other object.",
 	"binCleanupCreatedIn": "Created in",
 	"binCleanupLinkRemovedFrom": "Link removed from",
 	"binCleanupContextDeleted": "Deleted object",
-	"binCleanupIgnore": "Keep it",
+	"binCleanupIgnore": "Zamítnout návrh",
 	"binDeleteDisabledTooltip": "You can only delete objects you created"
 }

--- a/locales/da-DK.json
+++ b/locales/da-DK.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Skift til kompakt visning",
 	"binSwitchToDetailed": "Skift til detaljeret visning",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Oprydningsforslag",
+	"binCleanupTab": "Oprydning",
 	"binCleanupDescription": "Objekter og filer, der ikke længere er knyttet til det objekt, de blev oprettet i, og ikke bruges i noget andet objekt.",
 	"binCleanupCreatedIn": "Oprettet i",
 	"binCleanupLinkRemovedFrom": "Link fjernet fra",
 	"binCleanupContextDeleted": "Slettet objekt",
-	"binCleanupIgnore": "Behold det",
+	"binCleanupIgnore": "Afvis forslag",
 	"binDeleteDisabledTooltip": "Du kan kun slette objekter, du selv har oprettet"
 }

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Zur kompakten Ansicht wechseln",
 	"binSwitchToDetailed": "Zur Detailansicht wechseln",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Aufräumvorschläge",
+	"binCleanupTab": "Aufräumen",
 	"binCleanupDescription": "Objekte und Dateien, die nicht mehr mit dem Objekt verknüpft sind, in dem sie erstellt wurden, und in keinem anderen Objekt verwendet werden.",
 	"binCleanupCreatedIn": "Erstellt in",
 	"binCleanupLinkRemovedFrom": "Link entfernt aus",
 	"binCleanupContextDeleted": "Gelöschtes Objekt",
-	"binCleanupIgnore": "Behalten",
+	"binCleanupIgnore": "Vorschlag verwerfen",
 	"binDeleteDisabledTooltip": "Du kannst nur die von dir erstellten Objekte löschen"
 }

--- a/locales/el-GR.json
+++ b/locales/el-GR.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Switch to compact view",
 	"binSwitchToDetailed": "Switch to detailed view",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Cleanup suggestions",
+	"binCleanupTab": "Εκκαθάριση",
 	"binCleanupDescription": "Objects and files no longer linked to the object they were created in, and not used in any other object.",
 	"binCleanupCreatedIn": "Created in",
 	"binCleanupLinkRemovedFrom": "Link removed from",
 	"binCleanupContextDeleted": "Deleted object",
-	"binCleanupIgnore": "Keep it",
+	"binCleanupIgnore": "Απόρριψη πρότασης",
 	"binDeleteDisabledTooltip": "You can only delete objects you created"
 }

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Cambiar a vista compacta",
 	"binSwitchToDetailed": "Cambiar a vista detallada",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Sugerencias de limpieza",
+	"binCleanupTab": "Limpieza",
 	"binCleanupDescription": "Objetos y archivos que ya no están vinculados al objeto en el que se crearon ni se usan en otro objeto.",
 	"binCleanupCreatedIn": "Creado en",
 	"binCleanupLinkRemovedFrom": "Enlace eliminado de",
 	"binCleanupContextDeleted": "Objeto eliminado",
-	"binCleanupIgnore": "Conservar",
+	"binCleanupIgnore": "Descartar sugerencia",
 	"binDeleteDisabledTooltip": "Solo puedes eliminar los objetos que hayas creado tú"
 }

--- a/locales/fa-IR.json
+++ b/locales/fa-IR.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Switch to compact view",
 	"binSwitchToDetailed": "Switch to detailed view",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Cleanup suggestions",
+	"binCleanupTab": "پاک‌سازی",
 	"binCleanupDescription": "Objects and files no longer linked to the object they were created in, and not used in any other object.",
 	"binCleanupCreatedIn": "Created in",
 	"binCleanupLinkRemovedFrom": "Link removed from",
 	"binCleanupContextDeleted": "Deleted object",
-	"binCleanupIgnore": "Keep it",
+	"binCleanupIgnore": "رد پیشنهاد",
 	"binDeleteDisabledTooltip": "You can only delete objects you created"
 }

--- a/locales/fi-FI.json
+++ b/locales/fi-FI.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Switch to compact view",
 	"binSwitchToDetailed": "Switch to detailed view",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Cleanup suggestions",
+	"binCleanupTab": "Siivous",
 	"binCleanupDescription": "Objects and files no longer linked to the object they were created in, and not used in any other object.",
 	"binCleanupCreatedIn": "Created in",
 	"binCleanupLinkRemovedFrom": "Link removed from",
 	"binCleanupContextDeleted": "Deleted object",
-	"binCleanupIgnore": "Keep it",
+	"binCleanupIgnore": "Hylkää ehdotus",
 	"binDeleteDisabledTooltip": "You can only delete objects you created"
 }

--- a/locales/fr-FR.json
+++ b/locales/fr-FR.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Passer à la vue compacte",
 	"binSwitchToDetailed": "Passer à la vue détaillée",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Suggestions de nettoyage",
+	"binCleanupTab": "Nettoyage",
 	"binCleanupDescription": "Les objets et les fichiers ne sont plus liés à l'objet dans lequel ils ont été créés et ne sont plus utilisés dans aucun autre objet.",
 	"binCleanupCreatedIn": "Créé en",
 	"binCleanupLinkRemovedFrom": "Lien supprimé de",
 	"binCleanupContextDeleted": "Objet supprimé",
-	"binCleanupIgnore": "Conserver",
+	"binCleanupIgnore": "Ignorer la suggestion",
 	"binDeleteDisabledTooltip": "Vous pouvez seulement supprimer les objets que vous avez créés"
 }

--- a/locales/fy-NL.json
+++ b/locales/fy-NL.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Switch to compact view",
 	"binSwitchToDetailed": "Switch to detailed view",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Cleanup suggestions",
+	"binCleanupTab": "Opskjinning",
 	"binCleanupDescription": "Objects and files no longer linked to the object they were created in, and not used in any other object.",
 	"binCleanupCreatedIn": "Created in",
 	"binCleanupLinkRemovedFrom": "Link removed from",
 	"binCleanupContextDeleted": "Deleted object",
-	"binCleanupIgnore": "Keep it",
+	"binCleanupIgnore": "Suggestje negearje",
 	"binDeleteDisabledTooltip": "You can only delete objects you created"
 }

--- a/locales/gl-ES.json
+++ b/locales/gl-ES.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Switch to compact view",
 	"binSwitchToDetailed": "Switch to detailed view",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Cleanup suggestions",
+	"binCleanupTab": "Limpeza",
 	"binCleanupDescription": "Objects and files no longer linked to the object they were created in, and not used in any other object.",
 	"binCleanupCreatedIn": "Created in",
 	"binCleanupLinkRemovedFrom": "Link removed from",
 	"binCleanupContextDeleted": "Deleted object",
-	"binCleanupIgnore": "Keep it",
+	"binCleanupIgnore": "Descartar suxestión",
 	"binDeleteDisabledTooltip": "You can only delete objects you created"
 }

--- a/locales/he-IL.json
+++ b/locales/he-IL.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "מעבר לתצוגה מצומצמת",
 	"binSwitchToDetailed": "מעבר לתצוגה מפורטת",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Cleanup suggestions",
+	"binCleanupTab": "ניקוי",
 	"binCleanupDescription": "Objects and files no longer linked to the object they were created in, and not used in any other object.",
 	"binCleanupCreatedIn": "Created in",
 	"binCleanupLinkRemovedFrom": "Link removed from",
 	"binCleanupContextDeleted": "Deleted object",
-	"binCleanupIgnore": "Keep it",
+	"binCleanupIgnore": "התעלם מההצעה",
 	"binDeleteDisabledTooltip": "You can only delete objects you created"
 }

--- a/locales/hi-IN.json
+++ b/locales/hi-IN.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "कॉम्पैक्ट व्यू पर स्विच करें",
 	"binSwitchToDetailed": "विस्तृत व्यू पर स्विच करें",
 	"binStackCount": "+%d",
-	"binCleanupTab": "क्लीनअप सुझाव",
+	"binCleanupTab": "क्लीनअप",
 	"binCleanupDescription": "ऐसे ऑब्जेक्ट और फ़ाइलें जो अब उस ऑब्जेक्ट से लिंक नहीं हैं जिसमें वे बनाए गए थे, और किसी अन्य ऑब्जेक्ट में उपयोग नहीं की गई हैं।",
 	"binCleanupCreatedIn": "में बनाया गया",
 	"binCleanupLinkRemovedFrom": "से लिंक हटाया गया",
 	"binCleanupContextDeleted": "हटाया गया ऑब्जेक्ट",
-	"binCleanupIgnore": "इसे रखें",
+	"binCleanupIgnore": "सुझाव खारिज करें",
 	"binDeleteDisabledTooltip": "आप केवल अपने द्वारा बनाए गए ऑब्जेक्ट ही हटा सकते हैं"
 }

--- a/locales/hu-HU.json
+++ b/locales/hu-HU.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Switch to compact view",
 	"binSwitchToDetailed": "Váltás részletes nézetre",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Cleanup suggestions",
+	"binCleanupTab": "Tisztítás",
 	"binCleanupDescription": "Objects and files no longer linked to the object they were created in, and not used in any other object.",
 	"binCleanupCreatedIn": "Created in",
 	"binCleanupLinkRemovedFrom": "Link removed from",
 	"binCleanupContextDeleted": "Deleted object",
-	"binCleanupIgnore": "Keep it",
+	"binCleanupIgnore": "Javaslat elvetése",
 	"binDeleteDisabledTooltip": "Csak az általad létrehozott objektumokat törölheted"
 }

--- a/locales/id-ID.json
+++ b/locales/id-ID.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Beralih ke tampilan ringkas",
 	"binSwitchToDetailed": "Beralih ke tampilan detail",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Saran pembersihan",
+	"binCleanupTab": "Pembersihan",
 	"binCleanupDescription": "Objek dan berkas yang tidak lagi tertaut ke objek tempat asal pembuatannya, dan tidak digunakan di objek lain mana pun.",
 	"binCleanupCreatedIn": "Dibuat di",
 	"binCleanupLinkRemovedFrom": "Tautan dihapus dari",
 	"binCleanupContextDeleted": "Objek terhapus",
-	"binCleanupIgnore": "Simpan",
+	"binCleanupIgnore": "Abaikan saran",
 	"binDeleteDisabledTooltip": "Kamu hanya bisa menghapus objek yang kamu buat"
 }

--- a/locales/it-IT.json
+++ b/locales/it-IT.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Passa alla vista compatta",
 	"binSwitchToDetailed": "Passa alla vista dettagliata",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Cleanup suggestions",
+	"binCleanupTab": "Pulizia",
 	"binCleanupDescription": "Objects and files no longer linked to the object they were created in, and not used in any other object.",
 	"binCleanupCreatedIn": "Created in",
 	"binCleanupLinkRemovedFrom": "Link removed from",
 	"binCleanupContextDeleted": "Deleted object",
-	"binCleanupIgnore": "Keep it",
+	"binCleanupIgnore": "Ignora suggerimento",
 	"binDeleteDisabledTooltip": "Puoi eliminare solo gli oggetti che hai creato"
 }

--- a/locales/ja-JP.json
+++ b/locales/ja-JP.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "コンパクト表示に切り替え",
 	"binSwitchToDetailed": "詳細表示に切り替え",
 	"binStackCount": "%d件",
-	"binCleanupTab": "クリーンアップの提案",
+	"binCleanupTab": "クリーンアップ",
 	"binCleanupDescription": "作成元のオブジェクトとのリンクが解除され、他のどのオブジェクトでも使用されていないオブジェクトとファイル。",
 	"binCleanupCreatedIn": "作成元",
 	"binCleanupLinkRemovedFrom": "リンクの削除元",
 	"binCleanupContextDeleted": "削除されたオブジェクト",
-	"binCleanupIgnore": "残す",
+	"binCleanupIgnore": "提案を却下",
 	"binDeleteDisabledTooltip": "他のユーザーが作成したオブジェクトは削除できません"
 }

--- a/locales/ko-KR.json
+++ b/locales/ko-KR.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "요약 보기로 전환",
 	"binSwitchToDetailed": "상세 보기로 전환",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Cleanup suggestions",
+	"binCleanupTab": "정리",
 	"binCleanupDescription": "Objects and files no longer linked to the object they were created in, and not used in any other object.",
 	"binCleanupCreatedIn": "Created in",
 	"binCleanupLinkRemovedFrom": "Link removed from",
 	"binCleanupContextDeleted": "Deleted object",
-	"binCleanupIgnore": "Keep it",
+	"binCleanupIgnore": "제안 무시",
 	"binDeleteDisabledTooltip": "자신이 만든 객체만 삭제할 수 있습니다."
 }

--- a/locales/lt-LT.json
+++ b/locales/lt-LT.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Perjungti į kompaktišką rodinį",
 	"binSwitchToDetailed": "Perjungti į išsamų rodinį",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Valymo pasiūlymai",
+	"binCleanupTab": "Valymas",
 	"binCleanupDescription": "Objektai ir failai, nebesusieti su objektu, kuriame buvo sukurti, ir nenaudojami jokiame kitame objekte.",
 	"binCleanupCreatedIn": "Sukurta",
 	"binCleanupLinkRemovedFrom": "Nuoroda pašalinta iš",
 	"binCleanupContextDeleted": "Ištrintas objektas",
-	"binCleanupIgnore": "Palikti",
+	"binCleanupIgnore": "Atmesti pasiūlymą",
 	"binDeleteDisabledTooltip": "Gali ištrinti tik savo sukurtus objektus"
 }

--- a/locales/ms-MY.json
+++ b/locales/ms-MY.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Switch to compact view",
 	"binSwitchToDetailed": "Switch to detailed view",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Cleanup suggestions",
+	"binCleanupTab": "Pembersihan",
 	"binCleanupDescription": "Objects and files no longer linked to the object they were created in, and not used in any other object.",
 	"binCleanupCreatedIn": "Created in",
 	"binCleanupLinkRemovedFrom": "Link removed from",
 	"binCleanupContextDeleted": "Deleted object",
-	"binCleanupIgnore": "Keep it",
+	"binCleanupIgnore": "Abaikan cadangan",
 	"binDeleteDisabledTooltip": "You can only delete objects you created"
 }

--- a/locales/nl-NL.json
+++ b/locales/nl-NL.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Overschakelen naar compacte weergave",
 	"binSwitchToDetailed": "Overschakelen naar gedetailleerde weergave",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Opschoonsuggesties",
+	"binCleanupTab": "Opschonen",
 	"binCleanupDescription": "Objecten en bestanden die niet meer gekoppeld zijn aan het object waarin ze zijn gemaakt en die in geen enkel ander object worden gebruikt.",
 	"binCleanupCreatedIn": "Gemaakt in",
 	"binCleanupLinkRemovedFrom": "Link verwijderd uit",
 	"binCleanupContextDeleted": "Verwijderd object",
-	"binCleanupIgnore": "Behouden",
+	"binCleanupIgnore": "Suggestie negeren",
 	"binDeleteDisabledTooltip": "Je kunt alleen objecten verwijderen die je zelf hebt gemaakt"
 }

--- a/locales/no-NO.json
+++ b/locales/no-NO.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Bytt til kompakt visning",
 	"binSwitchToDetailed": "Bytt til detaljert visning",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Oppryddingsforslag",
+	"binCleanupTab": "Opprydding",
 	"binCleanupDescription": "Objekter og filer som ikke lenger er koblet til objektet de ble opprettet i, og som ikke brukes i noe annet objekt.",
 	"binCleanupCreatedIn": "Opprettet i",
 	"binCleanupLinkRemovedFrom": "Lenke fjernet fra",
 	"binCleanupContextDeleted": "Slettet objekt",
-	"binCleanupIgnore": "Behold det",
+	"binCleanupIgnore": "Avvis forslag",
 	"binDeleteDisabledTooltip": "Du kan bare slette objekter du har opprettet"
 }

--- a/locales/pl-PL.json
+++ b/locales/pl-PL.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Przełącz na widok kompaktowy",
 	"binSwitchToDetailed": "Przełącz na widok szczegółowy",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Sugestie czyszczenia",
+	"binCleanupTab": "Czyszczenie",
 	"binCleanupDescription": "Obiekty i pliki, które nie są już połączone z obiektem, w którym zostały utworzone, i nie są używane w żadnym innym obiekcie.",
 	"binCleanupCreatedIn": "Utworzono w",
 	"binCleanupLinkRemovedFrom": "Link usunięto z",
 	"binCleanupContextDeleted": "Usunięty obiekt",
-	"binCleanupIgnore": "Zachowaj",
+	"binCleanupIgnore": "Odrzuć sugestię",
 	"binDeleteDisabledTooltip": "Możesz usuwać tylko obiekty, które sam utworzyłeś"
 }

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Alternar para visualização compacta",
 	"binSwitchToDetailed": "Alternar para exibição detalhada",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Sugestões de limpeza",
+	"binCleanupTab": "Limpeza",
 	"binCleanupDescription": "Objetos e arquivos que não estão mais vinculados ao objeto em que foram criados e não são usados em nenhum outro objeto.",
 	"binCleanupCreatedIn": "Criado em",
 	"binCleanupLinkRemovedFrom": "Link removido de",
 	"binCleanupContextDeleted": "Objeto excluído",
-	"binCleanupIgnore": "Manter",
+	"binCleanupIgnore": "Dispensar sugestão",
 	"binDeleteDisabledTooltip": "Você só pode excluir objetos que você criou"
 }

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Muda para a vista compacta",
 	"binSwitchToDetailed": "Mudar para a vista detalhada",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Cleanup suggestions",
+	"binCleanupTab": "Limpeza",
 	"binCleanupDescription": "Objects and files no longer linked to the object they were created in, and not used in any other object.",
 	"binCleanupCreatedIn": "Created in",
 	"binCleanupLinkRemovedFrom": "Link removed from",
 	"binCleanupContextDeleted": "Deleted object",
-	"binCleanupIgnore": "Keep it",
+	"binCleanupIgnore": "Dispensar sugestão",
 	"binDeleteDisabledTooltip": "Só podes eliminar objectos que tu criaste"
 }

--- a/locales/ro-RO.json
+++ b/locales/ro-RO.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Switch to compact view",
 	"binSwitchToDetailed": "Switch to detailed view",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Cleanup suggestions",
+	"binCleanupTab": "Curățare",
 	"binCleanupDescription": "Objects and files no longer linked to the object they were created in, and not used in any other object.",
 	"binCleanupCreatedIn": "Created in",
 	"binCleanupLinkRemovedFrom": "Link removed from",
 	"binCleanupContextDeleted": "Deleted object",
-	"binCleanupIgnore": "Keep it",
+	"binCleanupIgnore": "Ignoră sugestia",
 	"binDeleteDisabledTooltip": "You can only delete objects you created"
 }

--- a/locales/ru-RU.json
+++ b/locales/ru-RU.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Переключить на компактный вид",
 	"binSwitchToDetailed": "Переключить на подробный вид",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Предложения по очистке",
+	"binCleanupTab": "Очистка",
 	"binCleanupDescription": "Объекты и файлы, больше не связанные с объектом, в котором они были созданы, и не используемые ни в одном другом объекте.",
 	"binCleanupCreatedIn": "Создано в",
 	"binCleanupLinkRemovedFrom": "Ссылка удалена из",
 	"binCleanupContextDeleted": "Удалённый объект",
-	"binCleanupIgnore": "Оставить",
+	"binCleanupIgnore": "Отклонить предложение",
 	"binDeleteDisabledTooltip": "Вы можете удалять только созданные вами объекты"
 }

--- a/locales/sk-SK.json
+++ b/locales/sk-SK.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Switch to compact view",
 	"binSwitchToDetailed": "Switch to detailed view",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Cleanup suggestions",
+	"binCleanupTab": "Čistenie",
 	"binCleanupDescription": "Objects and files no longer linked to the object they were created in, and not used in any other object.",
 	"binCleanupCreatedIn": "Created in",
 	"binCleanupLinkRemovedFrom": "Link removed from",
 	"binCleanupContextDeleted": "Deleted object",
-	"binCleanupIgnore": "Keep it",
+	"binCleanupIgnore": "Zamietnuť návrh",
 	"binDeleteDisabledTooltip": "Môžete odstrániť len objekty, ktoré ste vytvorili"
 }

--- a/locales/sv-SE.json
+++ b/locales/sv-SE.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Switch to compact view",
 	"binSwitchToDetailed": "Switch to detailed view",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Cleanup suggestions",
+	"binCleanupTab": "Städning",
 	"binCleanupDescription": "Objects and files no longer linked to the object they were created in, and not used in any other object.",
 	"binCleanupCreatedIn": "Created in",
 	"binCleanupLinkRemovedFrom": "Link removed from",
 	"binCleanupContextDeleted": "Deleted object",
-	"binCleanupIgnore": "Keep it",
+	"binCleanupIgnore": "Avvisa förslag",
 	"binDeleteDisabledTooltip": "You can only delete objects you created"
 }

--- a/locales/th-TH.json
+++ b/locales/th-TH.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Switch to compact view",
 	"binSwitchToDetailed": "Switch to detailed view",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Cleanup suggestions",
+	"binCleanupTab": "ล้างข้อมูล",
 	"binCleanupDescription": "Objects and files no longer linked to the object they were created in, and not used in any other object.",
 	"binCleanupCreatedIn": "Created in",
 	"binCleanupLinkRemovedFrom": "Link removed from",
 	"binCleanupContextDeleted": "Deleted object",
-	"binCleanupIgnore": "Keep it",
+	"binCleanupIgnore": "ปฏิเสธคำแนะนำ",
 	"binDeleteDisabledTooltip": "You can only delete objects you created"
 }

--- a/locales/tl-PH.json
+++ b/locales/tl-PH.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Switch to compact view",
 	"binSwitchToDetailed": "Switch to detailed view",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Cleanup suggestions",
+	"binCleanupTab": "Paglilinis",
 	"binCleanupDescription": "Objects and files no longer linked to the object they were created in, and not used in any other object.",
 	"binCleanupCreatedIn": "Created in",
 	"binCleanupLinkRemovedFrom": "Link removed from",
 	"binCleanupContextDeleted": "Deleted object",
-	"binCleanupIgnore": "Keep it",
+	"binCleanupIgnore": "Balewalain ang Mungkahi",
 	"binDeleteDisabledTooltip": "You can only delete objects you created"
 }

--- a/locales/tr-TR.json
+++ b/locales/tr-TR.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Derli toplu görünüme geç",
 	"binSwitchToDetailed": "Ayrıntılı görünüme geç",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Temizleme önerileri",
+	"binCleanupTab": "Temizlik",
 	"binCleanupDescription": "Oluşturuldukları nesneyle artık bağlantılı olmayan ve başka hiçbir nesnede kullanılmayan nesneler ve dosyalar.",
 	"binCleanupCreatedIn": "Oluşturulma",
 	"binCleanupLinkRemovedFrom": "Bağlantı şu adresten kaldırıldı",
 	"binCleanupContextDeleted": "Silinen nesne",
-	"binCleanupIgnore": "Sakla",
+	"binCleanupIgnore": "Öneriyi reddet",
 	"binDeleteDisabledTooltip": "Sadece kendi oluşturduğun nesneleri silebilirsin"
 }

--- a/locales/uk-UA.json
+++ b/locales/uk-UA.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Перемкнути на компактне подання",
 	"binSwitchToDetailed": "Перемкнути на детальне подання",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Пропозиції з очищення",
+	"binCleanupTab": "Очищення",
 	"binCleanupDescription": "Об'єкти та файли, більше не пов'язані з об'єктом, у якому їх створено, і не використовувані в жодному іншому об'єкті.",
 	"binCleanupCreatedIn": "Створено в",
 	"binCleanupLinkRemovedFrom": "Посилання вилучено з",
 	"binCleanupContextDeleted": "Видалений об'єкт",
-	"binCleanupIgnore": "Залишити",
+	"binCleanupIgnore": "Відхилити пропозицію",
 	"binDeleteDisabledTooltip": "Ви можете видаляти лише об'єкти, які створили ви"
 }

--- a/locales/vi-VN.json
+++ b/locales/vi-VN.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "Switch to compact view",
 	"binSwitchToDetailed": "Switch to detailed view",
 	"binStackCount": "+%d",
-	"binCleanupTab": "Cleanup suggestions",
+	"binCleanupTab": "Dọn dẹp",
 	"binCleanupDescription": "Objects and files no longer linked to the object they were created in, and not used in any other object.",
 	"binCleanupCreatedIn": "Created in",
 	"binCleanupLinkRemovedFrom": "Link removed from",
 	"binCleanupContextDeleted": "Deleted object",
-	"binCleanupIgnore": "Keep it",
+	"binCleanupIgnore": "Bỏ qua gợi ý",
 	"binDeleteDisabledTooltip": "You can only delete objects you created"
 }

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "切换到紧凑视图",
 	"binSwitchToDetailed": "切换到详细信息视图",
 	"binStackCount": "+%d",
-	"binCleanupTab": "清理建议",
+	"binCleanupTab": "清理",
 	"binCleanupDescription": "已不再关联到创建它们的对象，且未被任何其他对象使用的对象和文件。",
 	"binCleanupCreatedIn": "创建于",
 	"binCleanupLinkRemovedFrom": "已取消关联",
 	"binCleanupContextDeleted": "已删除的对象",
-	"binCleanupIgnore": "保留",
+	"binCleanupIgnore": "忽略建议",
 	"binDeleteDisabledTooltip": "您只能删除您创建的对象"
 }

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -2702,11 +2702,11 @@
 	"binSwitchToCompact": "切換到精簡視圖",
 	"binSwitchToDetailed": "切換到詳細視圖",
 	"binStackCount": "+%d",
-	"binCleanupTab": "清理建議",
+	"binCleanupTab": "清理",
 	"binCleanupDescription": "不再連結到其原始建立物件，且未在任何其他物件中使用的物件與檔案。",
 	"binCleanupCreatedIn": "創建於",
 	"binCleanupLinkRemovedFrom": "已從以下項目移除連結",
 	"binCleanupContextDeleted": "刪除物件",
-	"binCleanupIgnore": "保留",
+	"binCleanupIgnore": "忽略建議",
 	"binDeleteDisabledTooltip": "你只能刪除你所建立的物件。"
 }


### PR DESCRIPTION
The English source for two Bin/Cleanup strings changed, so their translations were stale (17 languages had translated the old wording) or English-fallback (22 languages):

- `binCleanupTab`: "Cleanup suggestions" → **"Cleanup"** (shortened tab label)
- `binCleanupIgnore`: "Keep it" → **"Dismiss suggestion"** (same action — reject the cleanup suggestion / keep the object — just reworded)

Re-translated both keys for **39 languages** (Sonnet, using each locale's existing register as reference). Concise UI labels, no placeholders. Machine-translated → **unapproved**; a human proofreading pass is welcome.

Also being uploaded into Crowdin directly so the project DB stays consistent.

The 20 very sparse locales that don't contain these keys were left untouched (they fall back to the new English).